### PR TITLE
Remove futures-preview and updated tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-tokio = "0.2.0-alpha.4"
-futures-preview = "=0.3.0-alpha.18"
+tokio = "0.2.0-alpha.6"
 
 [dev-dependencies]
 bytes = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,13 @@
 //! A fake stream for testing network applications backed by buffers.
 #![warn(missing_docs)]
 
-extern crate futures;
 extern crate tokio;
 
-use std::task::Context;
-use std::pin::Pin;
 use std::io;
 use std::io::{Cursor, Read, Write};
-use futures::Poll;
+use std::pin::Pin;
+use std::task::Context;
+use std::task::Poll;
 use tokio::io::{AsyncRead, AsyncWrite};
 
 /// A fake stream for testing network applications backed by buffers.
@@ -78,21 +77,14 @@ impl AsyncWrite for MockStream {
         Poll::Ready(self.write(buf))
     }
 
-    fn poll_flush(
-        mut self: Pin<&mut Self>,
-        _cx: &mut Context<'_>
-    ) -> Poll<Result<(), io::Error>> {
+    fn poll_flush(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
         Poll::Ready(self.flush())
     }
 
-    fn poll_shutdown(
-        self: Pin<&mut Self>,
-        _cx: &mut Context<'_>
-    ) -> Poll<Result<(), io::Error>> {
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
         Poll::Ready(Ok(()))
     }
 }
-
 
 #[cfg(test)]
 mod tests;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,15 +1,18 @@
 extern crate bytes;
 
-use std::{io, str};
-use super::MockStream;
 use self::bytes::{BufMut, BytesMut};
-use futures::{SinkExt, StreamExt};
-use tokio::codec::{Encoder, Decoder};
+use super::MockStream;
+use std::{io, str};
+use tokio::codec::{Decoder, Encoder};
+use tokio::prelude::*;
 
 #[tokio::test]
 async fn writing_to_mockstream() {
     let mut stream = LineCodec::new().framed(MockStream::empty());
-    stream.send("This is a test of the emergency broadcast system.".to_owned()).await.unwrap();
+    stream
+        .send("This is a test of the emergency broadcast system.".to_owned())
+        .await
+        .unwrap();
     let inner = stream.into_inner();
     assert!(inner.received().is_empty());
     let expected = b"This is a test of the emergency broadcast system.\n";
@@ -52,7 +55,7 @@ impl Decoder for LineCodec {
             return match str::from_utf8(&line.as_ref()) {
                 Ok(s) => Ok(Some(s.to_string())),
                 Err(_) => Err(io::Error::new(io::ErrorKind::Other, "invalid string")),
-            }
+            };
         }
 
         Ok(None)


### PR DESCRIPTION
Remove the need for `futures-preview` and upgraded to latest version of `tokio`. It wasn't compiling with the latest version of `tokio`.